### PR TITLE
Include keyboard

### DIFF
--- a/MMM-Bring.js
+++ b/MMM-Bring.js
@@ -13,7 +13,7 @@ Module.register("MMM-Bring", {
         maxItems: 0,
         maxLatestItems: 0,
         locale: "de-DE",
-        touch: true
+        useKeyboard: false
     },
 
     getStyles: function () {
@@ -81,7 +81,7 @@ Module.register("MMM-Bring", {
                 bringList.appendChild(bringListItem);
             }
 
-            if (this.config.touch) {
+            if (this.config.useKeyboard) {
                 //include add button
                 const bringListAdd = document.createElement("div");
                 bringListAdd.className = "bring-list-item-add";

--- a/MMM-Bring.js
+++ b/MMM-Bring.js
@@ -142,7 +142,7 @@ Module.register("MMM-Bring", {
 
     openKeyboard: function() {
         console.log("MMM-Bring opening keyboard");
-        this.sendNotification("KEYBOARD", { key: "bring", style: "default"});
+        this.sendNotification("KEYBOARD", { key: "mmm-bring", style: "default"});
     },
 
     socketNotificationReceived: function (notification, payload) {

--- a/MMM-Bring.js
+++ b/MMM-Bring.js
@@ -167,7 +167,6 @@ Module.register("MMM-Bring", {
     },
 
     itemClicked: function (item) {
-        console.log("Item clicked: " + item.name);
         this.sendSocketNotification("PURCHASED_ITEM", item);
     }
 

--- a/MMM-Bring.js
+++ b/MMM-Bring.js
@@ -1,3 +1,4 @@
+/*jshint esversion: 6 */
 Module.register("MMM-Bring", {
 
     defaults: {
@@ -11,7 +12,8 @@ Module.register("MMM-Bring", {
         showLatestItems: false,
         maxItems: 0,
         maxLatestItems: 0,
-        locale: "de-DE"
+        locale: "de-DE",
+        touch: true
     },
 
     getStyles: function () {
@@ -78,6 +80,17 @@ Module.register("MMM-Bring", {
 
                 bringList.appendChild(bringListItem);
             }
+
+            if (this.config.touch) {
+                //include add button
+                const bringListAdd = document.createElement("div");
+                bringListAdd.className = "bring-list-item-add";
+                var self = this;
+                bringListAdd.onclick = function() { self.openKeyboard(); };
+                bringListAdd.innerHTML = "+";
+                bringList.appendChild(bringListAdd);
+            }
+
             container.appendChild(bringList);
         }
         if (this.config.showLatestItems && this.list && this.list.recently) {
@@ -127,6 +140,11 @@ Module.register("MMM-Bring", {
         return container;
     },
 
+    openKeyboard: function() {
+        console.log("MMM-Bring opening keyboard");
+        this.sendNotification("KEYBOARD", { key: "bring", style: "default"});
+    },
+
     socketNotificationReceived: function (notification, payload) {
         if (notification === "LIST_DATA") {
             this.list = payload;
@@ -135,8 +153,21 @@ Module.register("MMM-Bring", {
             this.sendSocketNotification("GET_LIST", this.config);
         }
     },
+    
+    notificationReceived: function(notification, payload) {
+        if (notification === "KEYBOARD_INPUT" && payload.key === "bring" && payload.message != '') {
+            var item = {
+                name: payload.message[0].toUpperCase() + payload.message.substring(1), 
+                purchase: false, 
+                listId: this.list.uuid
+            };
+            console.log("MMM-Bring received Keyboard input: " + item.name);
+            this.sendSocketNotification("PURCHASED_ITEM", item);
+        }
+    },
 
     itemClicked: function (item) {
+        console.log("Item clicked: " + item.name);
         this.sendSocketNotification("PURCHASED_ITEM", item);
     }
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Add this configuration into `config.js` file's
        showLatestItems: false,
        maxItems: 0,
        maxLatestItems: 0,
-       locale: "de-DE"
+       locale: "de-DE",
+       useKeyboard: false
     }
 }
 ```
@@ -62,6 +63,7 @@ Here is the configurable part of the module
 | `maxItems`           | Maximum items to display. <br>**Type:** `number` <br> **Default value:** `0` (all)
 | `maxLatestItems`     | Maximum recent items to display. <br>**Type:** `number` <br> **Default value:** `0` (all)
 | `locale`             | The locale. <br>**Type:** `string` <br> **Default value:** `de-DE`
+| `useKeyboard`        | Activate to use this module together with MMM-Keyboard <br>**Type:** `boolean` <br> **Default value:** `false`
 
 
 ### Valid locales

--- a/css/styles.css
+++ b/css/styles.css
@@ -37,6 +37,24 @@ h3 {
     font-style: normal;
     color: white;
     text-align: center;
+    border: 1px solid black;
+    border-radius: 5px;
+}
+
+.bring-list-item-add {
+    display: flex;
+    flex-direction: column;
+    width: 98px;
+    height: 116px;
+    margin: 2px;
+    font-size: 70px;
+    font-weight: bold;
+    color: white;
+    text-align: center;
+    border: 1px solid black;
+    border-radius: 5px;
+    background-color: grey;
+    justify-content: center;
 }
 
 .bring-list-item-upper-part-container {


### PR DESCRIPTION
This is a PR to include a keyboard to add items to the list. Instead of coding a keyboard into this module I added an "Add" button and a communication channel to the module [MMM-Keyboard](https://github.com/lavolp3/MMM-Keyboard) which would have to be installed separately.
Please have a look at it. If you like it I can complete the documentation in the README. 

![image](https://user-images.githubusercontent.com/20084205/78894345-293b5680-7a6d-11ea-9642-6861cf676ee7.png)
