### PR TITLE
adjusted keyword for keyboard

### DIFF
--- a/MMM-Bring.js
+++ b/MMM-Bring.js
@@ -155,7 +155,7 @@ Module.register("MMM-Bring", {
     },
     
     notificationReceived: function(notification, payload) {
-        if (notification === "KEYBOARD_INPUT" && payload.key === "bring" && payload.message != '') {
+        if (notification === "KEYBOARD_INPUT" && payload.key === "mmm-bring" && payload.message != '') {
             var item = {
                 name: payload.message[0].toUpperCase() + payload.message.substring(1), 
                 purchase: false, 


### PR DESCRIPTION
required change for the keyword was not duplicated to the `payload.key`condition requirement in the notification catch.
Corrected now. 
See https://github.com/lavolp3/MMM-Keyboard/issues/4